### PR TITLE
Fix build against Python3.6

### DIFF
--- a/cpp/py/Makefile
+++ b/cpp/py/Makefile
@@ -4,10 +4,10 @@ python: srwlpy.so
 
 srwlpy.so:
 	python setup.py build_ext --build-lib='../gcc'
-	cp ../gcc/srwlpy.so ../../env/work/srw_python/
+	cp ../gcc/srwlpy*.so ../../env/work/srw_python/
 	rm -rf build
 
 clean:
 	rm -rf build
-	rm -f ../gcc/srwlpy.so
+	rm -f ../gcc/srwlpy*.so
 	rm -f ../../env/work/srw_python/srwlpy.so


### PR DESCRIPTION
Build SRW against Python3.6 produces srwlpy.cpython-36m-x86_64-linux-gnu.so
instead of srwlpy.so that breaks make which stops the compilation process.
Change Makefile to cover both cases.

Built tested against Python2.7 and Python3.6.