### PR TITLE
Fix issues with build system and MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pyc
-
+*.o
+data_example*
+.idea

--- a/Makefile
+++ b/Makefile
@@ -28,14 +28,15 @@ nofftw: core pylib
 
 all: clean fftw core pylib
 
-fftw:
+# FFTW2
+fftw2:
 	if [ ! -d "$(ext_dir)" ]; then \
 	    mkdir $(ext_dir); \
 	fi; \
 	cd $(ext_dir); \
-#	if [ ! -f "$(fftw2_file)" ]; then \
-#	    wget https://raw.githubusercontent.com/ochubar/SRW/master/ext_lib/$(fftw2_file); \
-#	fi; \
+	if [ ! -f "$(fftw2_file)" ]; then \
+	    wget http://www.fftw.org/fftw-2.1.5.tar.gz; \
+	fi; \
 	if [ -d "$(fftw2_dir)" ]; then \
 	    rm -rf $(fftw2_dir); \
 	fi; \
@@ -45,24 +46,49 @@ fftw:
 	sed 's/^CFLAGS = /CFLAGS = -fPIC /' -i Makefile; \
 	make -j8 && cp fftw/.libs/libfftw.a $(ext_dir); \
 	cd $(ext_dir); \
-	rm -rf $(fftw2_dir); \
+ 	rm -rf $(fftw2_dir); \
+
+# FFTW3 - Float
+fftw3f:
+	if [ ! -d "$(ext_dir)" ]; then \
+	    mkdir $(ext_dir); \
+	fi; \
+	cd $(ext_dir); \
 	if [ -d "$(fftw3_dir)" ]; then \
 	    rm -rf $(fftw3_dir); \
+	fi; \
+	if [ ! -f "$(fftw3_file)" ]; then \
+	    wget http://www.fftw.org/fftw-3.3.8.tar.gz; \
 	fi; \
 	tar -zxf $(fftw3_file); \
 	cd $(fftw3_dir); \
 	./configure --enable-float --with-pic; \
 	sed 's/^CFLAGS = /CFLAGS = -fPIC /' -i Makefile; \
-	make -j8 && cp .libs/libfftw3f.a ../; \
+	make -j8 && cp .libs/libfftw3f.a $(ext_dir); \
 	cd $(ext_dir); \
 	rm -rf $(fftw3_dir); \
+
+# FFTW3
+fftw3:
+	if [ ! -d "$(ext_dir)" ]; then \
+	    mkdir $(ext_dir); \
+	fi; \
+	cd $(ext_dir); \
+	if [ -d "$(fftw3_dir)" ]; then \
+	    rm -rf $(fftw3_dir); \
+	fi; \
+	if [ ! -f "$(fftw3_file)" ]; then \
+	    wget http://www.fftw.org/fftw-3.3.8.tar.gz; \
+	fi; \
 	tar -zxf $(fftw3_file); \
 	cd $(fftw3_dir); \
 	./configure --with-pic; \
 	sed 's/^CFLAGS = /CFLAGS = -fPIC /' -i Makefile; \
-	make -j8 && cp .libs/libfftw3.a ../; \
+	make -j8 && cp .libs/libfftw3.a $(ext_dir); \
 	cd $(root_dir); \
 	rm -rf $(ext_dir)/$(fftw3_dir);
+
+fftw: fftw2 fftw3 fftw3f
 
 core: 
 	cd $(gcc_dir); make -j8 clean lib
@@ -71,7 +97,7 @@ pylib:
 	cd $(py_dir); make python
 
 clean:
-	rm -f $(ext_dir)/libfftw3f.a $(ext_dir)/libfftw3.a $(gcc_dir)/libsrw.a $(gcc_dir)/srwlpy*.so; \
+	rm -f $(ext_dir)/libfftw3f.a $(ext_dir)/libfftw3.a $(ext_dir)/libfftw.a $(gcc_dir)/libsrw.a $(gcc_dir)/srwlpy*.so; \
 	rm -rf $(ext_dir)/$(fftw2_dir)/ $(ext_dir)/$(fftw3_dir)/ py/build/;
 	if [ -d $(root_dir)/.git ]; then rm -f $(examples_dir)/srwlpy*.so && (git checkout $(examples_dir)/srwlpy*.so 2>/dev/null || :); fi;
 

--- a/cpp/gcc/Makefile
+++ b/cpp/gcc/Makefile
@@ -9,12 +9,26 @@ LIB_DIR=	$(SOFT_DEV_DIR)/../ext_lib
 
 MODE ?= 0
 
-#CC  = gcc
-#CXX = g++
-CC  = cc
-CXX = c++
 
-SRW_SRC_DEF=	-D_GNU_SOURCE -D__USE_XOPEN2K8 -DFFTW_ENABLE_FLOAT -D_GM_WITHOUT_BASE -DSRWLIB_STATIC -DNO_TIMER -DANSI_DECLARATORS -DTRILIBRARY -DLINUX
+CC=cc
+CXX=c++
+
+ifeq ($(OS),Windows_NT)
+	OSFLAG += -DWIN32
+else
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Linux)
+		OSFLAG += -DLINUX
+	endif
+	ifeq ($(UNAME_S),Darwin)
+		OSFLAG += -D__MAC__
+		CC  = gcc
+		CXX = g++ -stdlib=libc++ -mmacosx-version-min=10.9
+	endif
+endif
+
+
+SRW_SRC_DEF=	-D_GNU_SOURCE -D__USE_XOPEN2K8 -DFFTW_ENABLE_FLOAT -D_GM_WITHOUT_BASE -DSRWLIB_STATIC -DNO_TIMER -DANSI_DECLARATORS -DTRILIBRARY $(OSFLAG)
 CFLAGS=	-O3 -fPIC -I$(SRW_SRC_GEN_DIR) -I$(SRW_SRC_LIB_DIR) -I$(SH_SRC_PARSE_DIR) -I$(SH_SRC_GEN_MATH_DIR) $(SRW_SRC_DEF) 
 LDFLAGS=-L$(LIB_DIR) -lm 
 


### PR DESCRIPTION
## Summary
This PR addresses issues that were found while trying to install SRW at my computer.
Here are the issues that this Pull Request addresses:

- ../src/core/srsysuti.cpp:25:10: fatal error: 'sys/sysinfo.h' file not found
	This is due to -DLINUX being hardcoded at this file: cpp/gcc/Makefile
- fftw setup was wrong.
	It was missing the download part for the FFTW tarballs
	It was also inconsistent between the fftw2 and fftw3.
- make clean is not really clean
	It was leaving the libfftw.a at ext_lib

## Results
After the fixes above I can simply do:
- make all
- Add <srw_folder>/env/work/srw_python to my `PYTHONPATH`
- Run examples


## Other comments
I noticed the following that I would like to bring to your attention:
- many products are being version controlled and they can lead to bad linking. E.g:
	env/work/srw_python/srwlpy.so
	ext_lib/GlutViewer.lib
	ext_lib/GlutViewer64.lib
	ext_lib/fftw3_64.lib
	ext_lib/fftw3f_64.lib
	ext_lib/fftw64_f.lib
	ext_lib/fftw_f.lib
	ext_lib/glut32.lib
	ext_lib/glut64.lib
	ext_lib/libf2c.a
	ext_lib/libf2c.lib
	ext_lib/libfftw3_mac.a
	ext_lib/libfftw3f_mac.a
	ext_lib/libfftw_f_i686.a
	ext_lib/libfftw_f_x86_64.a
	ext_lib/libfftw_mac.a
	ext_lib/libfftwf_mac.a
	ext_lib/libpng.lib
	ext_lib/libpng64.lib
	ext_lib/zlib.lib
	ext_lib/zlib64.lib

- product SRW Library should never be on version control as it is specific to my compiler and system: env/work/srw_python/srwlpy.so and can lead to issues if not cleaned up properly.


Attn. @mrakitin I think that now your Conda recipe will build again for MacOS and Windows.