### PR TITLE
Update srwl_uti_brightness.py

### DIFF
--- a/env/work/srw_python/srwl_uti_brightness.py
+++ b/env/work/srw_python/srwl_uti_brightness.py
@@ -426,6 +426,8 @@ def interpBright(x,y,W,xmin,ymin,xstep,ystep,nx,ny):
     W00 = W[jx0,jy0]
     W01 = W[jx0,jy0+1]
     W10 = W[jx0+1,jy0]
-    #W11 = W[jx0+1,jy0+1]
+    W11 = W[jx0+1,jy0+1]
 
-    return W00 +  djx*(W01-W00) + djy*(W10-W00) #+ djx*djy*W11
+    A = W00 + djy*(W01-W00)
+    B = W10 + djy*(W11-W10)
+    return A + djx*(B - A)


### PR DESCRIPTION
Interpolation is incorrect.  This was most evident when plotting undulator brightness as a function of energy spread. See attached plot of the old and corrected.

![InterpModify](https://user-images.githubusercontent.com/5774032/154519894-b3e68b1a-12d6-435c-a216-f729b9511a0e.png)
