### PR TITLE
Fix imports and add CLI file viewer

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -78,11 +78,6 @@ jobs:
       #     set -vxeuo pipefail
       #     conda install -y -c conda-forge mpi4py openmpi
 
-      - name: Copy over README.md
-        run: |
-          set -vxeuo pipefail
-          cp README.md env/python
-
       - name: Install cibuildwheel on Linux
         if: runner.os == 'Linux'
         run: |
@@ -112,17 +107,6 @@ jobs:
           ls -la dist/*
           mkdir -p ../../dist
           cp dist/*.whl ../../dist/
-
-      # - name: Build sdist on Windows (for Python 3.11)
-      #   if: runner.os == 'Windows' && matrix.python-version == '3.11'
-      #   run: |
-      #     set -vxeuo pipefail
-      #     cd env/python
-      #     python -VV
-      #     python setup.py sdist
-      #     ls -la dist/*
-      #     mkdir -p ../../dist
-      #     cp dist/*.tar.gz ../../dist/
 
       - name: Publish wheels to GitHub artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -138,6 +138,9 @@ jobs:
           # Smoke import test:
           python -c "import srwpy; import srwpy.srwlpy"
 
+          # Check CLI tools:
+          srw-viewer --help
+
           python -m pip install -r env/python/requirements-dev.txt
           python -m pip list
 

--- a/env/python/setup.py
+++ b/env/python/setup.py
@@ -86,7 +86,7 @@ with open(os.path.join(base_dir, 'requirements.txt')) as requirements_file:
                     if not line.startswith('#')]
 
 setup(name='srwpy',
-      version='4.0.0b0',
+      version='4.0.0b1',
       description='This is SRW for Python',
       author='O. Chubar et al.',
       author_email='chubar@bnl.gov',
@@ -99,4 +99,7 @@ setup(name='srwpy',
       zip_safe=False,
       ext_modules=[CMakeExtension('srwlpy', original_src_dir, 'srwpy')],
       cmdclass=dict(build_ext=CMakeBuild),
+      entry_points={
+        'console_scripts': ['srw-viewer=srwpy.SRWLIB_ExampleViewDataFile:main'],
+        },
       )

--- a/env/python/setup.py
+++ b/env/python/setup.py
@@ -77,8 +77,8 @@ class CMakeBuild(build_ext):
 base_dir = os.path.dirname(os.path.realpath(__file__))
 original_src_dir = os.path.join(base_dir, '../..')
 
-#Read README.md for long_description
-long_description = open(os.path.join(base_dir, 'README.md')).read()
+# Read README.md for long_description
+long_description = open(os.path.join(original_src_dir, 'README.md')).read()
 
 with open(os.path.join(base_dir, 'requirements.txt')) as requirements_file:
     # Parse requirements.txt, ignoring any commented-out lines.

--- a/env/python/srwpy/SRWLIB_ExampleViewDataFile.py
+++ b/env/python/srwpy/SRWLIB_ExampleViewDataFile.py
@@ -15,7 +15,7 @@ except:
 import optparse
 import os
 
-if __name__=='__main__':
+def main():
     p = optparse.OptionParser()
     p.add_option('-f', '--infile', dest='infile', metavar='FILE', default='', help='input file name')
     p.add_option('-e', '--e', dest='e', metavar='NUMBER', type='float', default=0, help='photon energy')
@@ -58,3 +58,7 @@ if __name__=='__main__':
                        opt.scale, opt.width_pixels)
 
     uti_plot_show()
+
+
+if __name__ == "__main__":
+    main()

--- a/env/python/srwpy/uti_plot.py
+++ b/env/python/srwpy/uti_plot.py
@@ -57,7 +57,10 @@ def uti_plot_init(backend=DEFAULT_BACKEND, fname_format=None):
     global _backend
     if backend is not None:
         try:
-            import uti_plot_matplotlib
+            try:
+                from . import uti_plot_matplotlib
+            except:
+                import uti_plot_matplotlib
             _backend = uti_plot_matplotlib.Backend(backend, fname_format)
             return
         except:


### PR DESCRIPTION
This pull request fixes more imports (missed from #42) to be able to use the `srwpy.SRWLIB_ExampleViewDataFile.py` data file viewer.

Also, this adds a convenient script to avoid a long line to execute it
```console
$ python -m srwpy.SRWLIB_ExampleViewDataFile -f ex10_res_int_prop_me.dat
```
reduced to
```console
$ srw-viewer -f ex10_res_int_prop_me.dat
```
I added a step in the CI workflow to test the help for the script:
```console
$ srw-viewer --help

Usage: srw-viewer [options]

Options:
  -h, --help            show this help message and exit
  -f FILE, --infile=FILE
                        input file name
  -e NUMBER, --e=NUMBER
                        photon energy
  -x NUMBER, --x=NUMBER
                        horizontal position
  -y NUMBER, --y=NUMBER
                        vertical position
  -l NUMBER, --readlab=NUMBER
                        read labels from the file header (1) or not (0)
  -j NUMBER, --joined=NUMBER
                        place different graphs jointly into one figure (1) or
                        into separate figures (0)
  -m, --multicol_data   visualize multicolumn data
  --m_colx=STR          column for horizontal axis
  --m_coly=STR          column for vertical axis
  -s SCALE, --scale=SCALE
                        scale to use in plots (linear, log, log2, log10)
  -w WIDTH, --width-pixels=WIDTH
                        desired width of pixels
```

I updated the version to `4.0.0b1` for the next beta release.