### PR TITLE
Small fixes to keep up with dependency/component updates

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         host-os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         openmp: ["off"]
       fail-fast: false
 
@@ -26,7 +26,7 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set OpenMP mode
         if: matrix.openmp == 'on'
@@ -40,7 +40,7 @@ jobs:
           export MACOSX_DEPLOYMENT_TARGET="10.15"
           echo "MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}" >> $GITHUB_ENV
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: testenv
           allow-softlinks: true
@@ -84,6 +84,7 @@ jobs:
           set -vxeuo pipefail
           python -m pip install --upgrade pip
           python -m pip install cibuildwheel
+          python -m pip install packaging
           echo "CIBW_BEFORE_ALL=pip install cmake" >> $GITHUB_ENV
           PYTH_VER=${{ matrix.python-version }}
           PYTH_VER=${PYTH_VER//.}
@@ -103,15 +104,17 @@ jobs:
           set -vxeuo pipefail
           cd env/python
           python -VV
+          python -m pip install packaging
+          python -m pip install setuptools
           python setup.py bdist_wheel
           ls -la dist/*
           mkdir -p ../../dist
           cp dist/*.whl ../../dist/
 
       - name: Publish wheels to GitHub artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: srwpy-${{ matrix.host-os }}-Py_${{ matrix.python-version }}-OpenMP_${{ matrix.openmp }}
           path: dist/*
 
       - name: Install the package and test requirements
@@ -146,12 +149,11 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download wheels from GitHub artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: wheels
           path: dist/
 
       - name: Publish wheels to PyPI

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -155,8 +155,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: dist/
+          merge-multiple: true
 
       - name: Publish wheels to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          repository-url: https://test.pypi.org/legacy/
           packages-dir: ./dist/

--- a/cpp/cmake/CMakeLists.txt
+++ b/cpp/cmake/CMakeLists.txt
@@ -75,7 +75,9 @@ add_library(genesis OBJECT ${genesis_source_files})
 target_link_libraries(genesis genmath)
 target_include_directories(genesis PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../src/ext/genesis/genesis_july08/)
 target_compile_definitions(genesis PRIVATE ${SRW_DEFINITIONS})
-target_compile_options(genesis PRIVATE -std=c99 -Wno-implicit-int)
+if(UNIX)
+    target_compile_options(genesis PRIVATE -std=c99 -Wno-implicit-int)
+endif()
 
 #genmath
 set(genmath_source_files

--- a/cpp/cmake/CMakeLists.txt
+++ b/cpp/cmake/CMakeLists.txt
@@ -75,6 +75,7 @@ add_library(genesis OBJECT ${genesis_source_files})
 target_link_libraries(genesis genmath)
 target_include_directories(genesis PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../src/ext/genesis/genesis_july08/)
 target_compile_definitions(genesis PRIVATE ${SRW_DEFINITIONS})
+target_compile_options(genesis PRIVATE -std=c99 -Wno-implicit-int)
 
 #genmath
 set(genmath_source_files

--- a/cpp/gcc/Makefile
+++ b/cpp/gcc/Makefile
@@ -112,7 +112,7 @@ PRG= libsrw.a
 	$(CXX) $(CFLAGS) -c $<  
 
 %.o: $(SRW_SRC_GENESIS_DIR)/%.c
-	$(CC) $(CFLAGS) -c $<  
+	$(CC) $(CFLAGS) -c $< -std=c99 -Wno-implicit-int
 
 # HG30112023
 ifeq ($(MODE), cuda)

--- a/cpp/src/clients/python/srwlpy.cpp
+++ b/cpp/src/clients/python/srwlpy.cpp
@@ -3515,7 +3515,11 @@ void ParseDeviceParam(PyObject* oDev, double* &parGPUParam) //HG10202021 Convert
 		if(PyLong_Check(oDev)) {
 			parGPUParam = new double[2]; //HG08022024
 			parGPUParam[0] = 1; //OC: The number of parameters?
+#if PY_MAJOR_VERSION >=3 && PY_MINOR_VERSION >= 13 //HG16062025
+			parGPUParam[1] = (double)PyLong_AsInt(oDev);
+#else
 			parGPUParam[1] = (double)_PyLong_AsInt(oDev);
+#endif
 			return;
 		}
 	}

--- a/env/python/setup.py
+++ b/env/python/setup.py
@@ -85,7 +85,7 @@ with open(os.path.join(base_dir, 'requirements.txt')) as requirements_file:
     requirements = [line for line in requirements_file.read().splitlines()
                     if not line.startswith('#')]
 
-setup(name='srwpy',
+setup(name='srwpy-hgtest00',
       version='4.1.0', #'4.0.0b1',
       description='This is SRW for Python',
       author='O. Chubar et al.',

--- a/env/python/srwpy/srwl_uti_smp_rnd_obj2d.py
+++ b/env/python/srwpy/srwl_uti_smp_rnd_obj2d.py
@@ -11,7 +11,7 @@ import sys
 import random #OC01082020
 import numpy as np
 
-from skimage.draw import polygon, circle, ellipse
+from skimage.draw import polygon, ellipse
 
 # ********************** Get the distance between point jj and the other points
 def get_r1j( px, py, jj):

--- a/env/python/srwpy/uti_plot.py
+++ b/env/python/srwpy/uti_plot.py
@@ -57,7 +57,10 @@ def uti_plot_init(backend=DEFAULT_BACKEND, fname_format=None):
     global _backend
     if backend is not None:
         try:
-            import uti_plot_matplotlib
+            try:
+                from . import uti_plot_matplotlib
+            except:
+                import uti_plot_matplotlib
             _backend = uti_plot_matplotlib.Backend(backend, fname_format)
             return
         except:


### PR DESCRIPTION
There have been some updates to components we rely on, which break things during compilation or execution:
1. On the C/Python interface end, Python 3.13, which is the most current version, changed a function’s name (_PyLong_AsInt to PyLong_AsInt), causing compilation of SRW to fail . 
2. In srwl_uti_smp_rnd_obj2d.py, we import circle from skimage.draw, however, we don’t use it anywhere in the module. In recent versions, scikit-image has moved the circle class to elsewhere, so this causes an unnecessary error that is fixed by simply not importing circle.
3. Some components of the Github Actions workflow file need small updates to keep the workflow working.
4. Newer GCC versions have changed the default C standard used. This causes a compilation error for the Fortran code in genesis. This is fixed by passing -std=c99 -Wno-implicit-int to gcc when compiling genesis, allowing compilation to proceed. This should still be compatible with previous versions of gcc.
5. I missed a ‘try: from . import …’ fix in one location, which causes matplotlib plotting to fail when an SRW script is executed in certain ways.
