### PR TITLE
Replace repr with str for numpy 2

### DIFF
--- a/env/python/srwpy/examples/SRWLIB_Example02.py
+++ b/env/python/srwpy/examples/SRWLIB_Example02.py
@@ -142,13 +142,13 @@ def AuxSaveMagFldData(dispFld3D, xc, yc, zc, filePath):
             for ix in range(dispFld3D.nx):
                 if(arXdef == True):
                     x = dispFld3D.arX[ix] + xc
-                resStr = repr(x) + '\t' + repr(y) + '\t' + repr(z)
+                resStr = str(x) + '\t' + str(y) + '\t' + str(z)
                 if(arBxDef == True):
-                    resStr += '\t' + repr(dispFld3D.arBx[i])
+                    resStr += '\t' + str(dispFld3D.arBx[i])
                 if(arByDef == True):
-                    resStr += '\t' + repr(dispFld3D.arBy[i])
+                    resStr += '\t' + str(dispFld3D.arBy[i])
                 if(arBzDef == True):
-                    resStr += '\t' + repr(dispFld3D.arBz[i])
+                    resStr += '\t' + str(dispFld3D.arBz[i])
                 f.write(resStr + '\n')
                 i += 1
                 x += hx
@@ -172,13 +172,13 @@ def AuxSaveTrajData(traj, filePath):
         ctStep = (traj.ctEnd - traj.ctStart)/(traj.np - 1)
     ct = traj.ctStart
     for i in range(traj.np):
-        resStr = str(ct) + '\t' + repr(traj.arX[i]) + '\t' + repr(traj.arXp[i]) + '\t' + repr(traj.arY[i]) + '\t' + repr(traj.arYp[i]) + '\t' + repr(traj.arZ[i]) + '\t' + repr(traj.arZp[i])
+        resStr = str(ct) + '\t' + str(traj.arX[i]) + '\t' + str(traj.arXp[i]) + '\t' + str(traj.arY[i]) + '\t' + str(traj.arYp[i]) + '\t' + str(traj.arZ[i]) + '\t' + str(traj.arZp[i])
         if(hasattr(traj, 'arBx')):
-            resStr += '\t' + repr(traj.arBx[i])
+            resStr += '\t' + str(traj.arBx[i])
         if(hasattr(traj, 'arBy')):
-            resStr += '\t' + repr(traj.arBy[i])
+            resStr += '\t' + str(traj.arBy[i])
         if(hasattr(traj, 'arBz')):
-            resStr += '\t' + repr(traj.arBz[i])
+            resStr += '\t' + str(traj.arBz[i])
         f.write(resStr + '\n')        
         ct += ctStep
     f.close()

--- a/env/python/srwpy/examples/SRWLIB_Example04.py
+++ b/env/python/srwpy/examples/SRWLIB_Example04.py
@@ -102,17 +102,17 @@ optBL = SRWLOptC([optLens, optDrift], [propagParLens, propagParDrift]) #"Beamlin
 #def AuxSaveIntData(arI, mesh, filePath):
 #    f = open(filePath, 'w')
 #    f.write('#C-aligned Intensity (inner loop is vs photon energy, outer loop vs vertical position)\n')
-#    f.write('#' + repr(mesh.eStart) + ' #Initial Photon Energy [eV]\n')
-#    f.write('#' + repr(mesh.eFin) + ' #Final Photon Energy [eV]\n')
-#    f.write('#' + repr(mesh.ne) + ' #Number of points vs Photon Energy\n')
-#    f.write('#' + repr(mesh.xStart) + ' #Initial Horizontal Position [m]\n')
-#    f.write('#' + repr(mesh.xFin) + ' #Final Horizontal Position [m]\n')
-#    f.write('#' + repr(mesh.nx) + ' #Number of points vs Horizontal Position\n')
-#    f.write('#' + repr(mesh.yStart) + ' #Initial Vertical Position [m]\n')
-#    f.write('#' + repr(mesh.yFin) + ' #Final Vertical Position [m]\n')
-#    f.write('#' + repr(mesh.ny) + ' #Number of points vs Vertical Position\n')
+#    f.write('#' + str(mesh.eStart) + ' #Initial Photon Energy [eV]\n')
+#    f.write('#' + str(mesh.eFin) + ' #Final Photon Energy [eV]\n')
+#    f.write('#' + str(mesh.ne) + ' #Number of points vs Photon Energy\n')
+#    f.write('#' + str(mesh.xStart) + ' #Initial Horizontal Position [m]\n')
+#    f.write('#' + str(mesh.xFin) + ' #Final Horizontal Position [m]\n')
+#    f.write('#' + str(mesh.nx) + ' #Number of points vs Horizontal Position\n')
+#    f.write('#' + str(mesh.yStart) + ' #Initial Vertical Position [m]\n')
+#    f.write('#' + str(mesh.yFin) + ' #Final Vertical Position [m]\n')
+#    f.write('#' + str(mesh.ny) + ' #Number of points vs Vertical Position\n')
 #    for i in range(mesh.ne*mesh.nx*mesh.ny): #write all data into one column using "C-alignment" as a "flat" 1D array
-#        f.write(' ' + repr(arI[i]) + '\n')
+#        f.write(' ' + str(arI[i]) + '\n')
 #    f.close()
 
 #**********************Calculation (SRWLIB function calls) and post-processing

--- a/env/python/srwpy/examples/SRWLIB_Example05.py
+++ b/env/python/srwpy/examples/SRWLIB_Example05.py
@@ -75,13 +75,13 @@ def AuxSaveTrajData(traj, filePath):
         ctStep = (traj.ctEnd - traj.ctStart)/(traj.np - 1)
     ct = traj.ctStart
     for i in range(traj.np):
-        resStr = str(ct) + '\t' + repr(traj.arX[i]) + '\t' + repr(traj.arXp[i]) + '\t' + repr(traj.arY[i]) + '\t' + repr(traj.arYp[i]) + '\t' + repr(traj.arZ[i]) + '\t' + repr(traj.arZp[i])
+        resStr = str(ct) + '\t' + str(traj.arX[i]) + '\t' + str(traj.arXp[i]) + '\t' + str(traj.arY[i]) + '\t' + str(traj.arYp[i]) + '\t' + str(traj.arZ[i]) + '\t' + str(traj.arZp[i])
         if(hasattr(traj, 'arBx')):
-            resStr += '\t' + repr(traj.arBx[i])
+            resStr += '\t' + str(traj.arBx[i])
         if(hasattr(traj, 'arBy')):
-            resStr += '\t' + repr(traj.arBy[i])
+            resStr += '\t' + str(traj.arBy[i])
         if(hasattr(traj, 'arBz')):
-            resStr += '\t' + repr(traj.arBz[i])
+            resStr += '\t' + str(traj.arBz[i])
         f.write(resStr + '\n')        
         ct += ctStep
     f.close()
@@ -91,17 +91,17 @@ def AuxSaveTrajData(traj, filePath):
 #def AuxSaveIntData(arI, mesh, filePath):
 #    f = open(filePath, 'w')
 #    f.write('#C-aligned Intensity (inner loop is vs photon energy, outer loop vs vertical position)\n')
-#    f.write('#' + repr(mesh.eStart) + ' #Initial Photon Energy [eV]\n')
-#    f.write('#' + repr(mesh.eFin) + ' #Final Photon Energy [eV]\n')
-#    f.write('#' + repr(mesh.ne) + ' #Number of points vs Photon Energy\n')
-#    f.write('#' + repr(mesh.xStart) + ' #Initial Horizontal Position [m]\n')
-#    f.write('#' + repr(mesh.xFin) + ' #Final Horizontal Position [m]\n')
-#    f.write('#' + repr(mesh.nx) + ' #Number of points vs Horizontal Position\n')
-#    f.write('#' + repr(mesh.yStart) + ' #Initial Vertical Position [m]\n')
-#    f.write('#' + repr(mesh.yFin) + ' #Final Vertical Position [m]\n')
-#    f.write('#' + repr(mesh.ny) + ' #Number of points vs Vertical Position\n')
+#    f.write('#' + str(mesh.eStart) + ' #Initial Photon Energy [eV]\n')
+#    f.write('#' + str(mesh.eFin) + ' #Final Photon Energy [eV]\n')
+#    f.write('#' + str(mesh.ne) + ' #Number of points vs Photon Energy\n')
+#    f.write('#' + str(mesh.xStart) + ' #Initial Horizontal Position [m]\n')
+#    f.write('#' + str(mesh.xFin) + ' #Final Horizontal Position [m]\n')
+#    f.write('#' + str(mesh.nx) + ' #Number of points vs Horizontal Position\n')
+#    f.write('#' + str(mesh.yStart) + ' #Initial Vertical Position [m]\n')
+#    f.write('#' + str(mesh.yFin) + ' #Final Vertical Position [m]\n')
+#    f.write('#' + str(mesh.ny) + ' #Number of points vs Vertical Position\n')
 #    for i in range(mesh.ne*mesh.nx*mesh.ny): #write all data into one column using "C-alignment" as a "flat" 1D array
-#        f.write(' ' + repr(arI[i]) + '\n')
+#        f.write(' ' + str(arI[i]) + '\n')
 #    f.close()
 
 #**********************Defining Magnetic Field:

--- a/env/python/srwpy/examples/SRWLIB_Example06_PETRA.py
+++ b/env/python/srwpy/examples/SRWLIB_Example06_PETRA.py
@@ -208,13 +208,13 @@ def AuxSaveTrajData(traj, filePath):
         ctStep = (traj.ctEnd - traj.ctStart)/(traj.np - 1)
     ct = traj.ctStart
     for i in range(traj.np):
-        resStr = str(ct) + '\t' + repr(traj.arX[i]) + '\t' + repr(traj.arXp[i]) + '\t' + repr(traj.arY[i]) + '\t' + repr(traj.arYp[i]) + '\t' + repr(traj.arZ[i]) + '\t' + repr(traj.arZp[i])
+        resStr = str(ct) + '\t' + str(traj.arX[i]) + '\t' + str(traj.arXp[i]) + '\t' + str(traj.arY[i]) + '\t' + str(traj.arYp[i]) + '\t' + str(traj.arZ[i]) + '\t' + str(traj.arZp[i])
         if(hasattr(traj, 'arBx')):
-            resStr += '\t' + repr(traj.arBx[i])
+            resStr += '\t' + str(traj.arBx[i])
         if(hasattr(traj, 'arBy')):
-            resStr += '\t' + repr(traj.arBy[i])
+            resStr += '\t' + str(traj.arBy[i])
         if(hasattr(traj, 'arBz')):
-            resStr += '\t' + repr(traj.arBz[i])
+            resStr += '\t' + str(traj.arBz[i])
         f.write(resStr + '\n')        
         ct += ctStep
     f.close()

--- a/env/python/srwpy/examples/SRWLIB_Example12.py
+++ b/env/python/srwpy/examples/SRWLIB_Example12.py
@@ -311,7 +311,7 @@ def calcSE(_e_beam, _mag, _mesh, _bl, _sr_meth=1, _sr_prec=0.01, _sr_samp_fact=1
   sys.stdout.write('   Simulating Electric Field Wavefront Propagation ... '); sys.stdout.flush()
   t0 = time.time()
   srwl.PropagElecField(wfr, _bl)
-  sys.stdout.write('done\n   lasted '+repr(round(time.time() - t0))+' s\n')
+  sys.stdout.write('done\n   lasted '+str(round(time.time() - t0))+' s\n')
   mesh1 = deepcopy(wfr.mesh)  
   sys.stdout.write('   Extracting Intensity from the Propagated Electric Field  ... '); sys.stdout.flush()
   arI1 = array('f', [0]*mesh1.nx*mesh1.ny) #"flat" 2D array to take intensity data
@@ -382,7 +382,7 @@ if __name__=="__main__":
   e_beam = setElecBeam(-1.9)
   beamline = setBeamline(opt.en, opt.noptel)
 
-  fileNameSuf = opt.fnsuf+'_'+repr(enPhExact)+"eV.dat"
+  fileNameSuf = opt.fnsuf+'_'+str(enPhExact)+"eV.dat"
 
   if(opt.melec <= 1):
     calcSE(e_beam, mag, mesh, beamline, _sr_samp_fact=opt.isamp, _fnsuf=fileNameSuf)

--- a/env/python/srwpy/examples/SRWLIB_Example14.py
+++ b/env/python/srwpy/examples/SRWLIB_Example14.py
@@ -378,7 +378,7 @@ if(meshP0vsT != None):
 if(meshP0vsXY != None):
     plotMeshP0vsX = [meshP0vsXY.xStart, meshP0vsXY.xFin, meshP0vsXY.nx]
     plotMeshP0vsY = [meshP0vsXY.yStart, meshP0vsXY.yFin, meshP0vsXY.ny]
-    uti_plot2d1d(arP0vsXY, plotMeshP0vsX, plotMeshP0vsY, x=0, y=0, labels=['Horizontal Position', 'Vertical Position', 'Power Density Before Propagation at t=' + repr(round(tc0*1.e+15)) + ' fs'], units=['m', 'm', 'W/mm^2'])
+    uti_plot2d1d(arP0vsXY, plotMeshP0vsX, plotMeshP0vsY, x=0, y=0, labels=['Horizontal Position', 'Vertical Position', 'Power Density Before Propagation at t=' + str(round(tc0*1.e+15)) + ' fs'], units=['m', 'm', 'W/mm^2'])
 
 if(meshI0vsE != None):
     plotMeshI0vsE = [meshI0vsE.eStart, meshI0vsE.eFin, meshI0vsE.ne]
@@ -387,7 +387,7 @@ if(meshI0vsE != None):
 
 plotMeshI0vsX = [meshI0vsXY.xStart, meshI0vsXY.xFin, meshI0vsXY.nx]
 plotMeshI0vsY = [meshI0vsXY.yStart, meshI0vsXY.yFin, meshI0vsXY.ny]
-uti_plot2d1d(arI0vsXY, plotMeshI0vsX, plotMeshI0vsY, labels=['Horizontal Position', 'Vertical Position', 'Spectral Fluence Before Propagation at E=' + repr(round(ec0)) + ' eV'], units=['m', 'm', 'J/eV/mm^2'])
+uti_plot2d1d(arI0vsXY, plotMeshI0vsX, plotMeshI0vsY, labels=['Horizontal Position', 'Vertical Position', 'Spectral Fluence Before Propagation at E=' + str(round(ec0)) + ' eV'], units=['m', 'm', 'J/eV/mm^2'])
 
 if(arF0vsXY != None):
     uti_plot2d1d(arF0vsXY, plotMeshI0vsX, plotMeshI0vsY, x=0, y=0, labels=['Horizontal Position', 'Vertical Position', 'Fluence Before Propagation'], units=['m', 'm', 'J/mm^2'])
@@ -400,7 +400,7 @@ if(meshI1vsE != None):
 
 plotMeshI1vsX = [meshI1vsXY.xStart, meshI1vsXY.xFin, meshI1vsXY.nx]
 plotMeshI1vsY = [meshI1vsXY.yStart, meshI1vsXY.yFin, meshI1vsXY.ny]
-uti_plot2d1d(arI1vsXY, plotMeshI1vsX, plotMeshI1vsY, labels=['Horizontal Position', 'Vertical Position', 'Spectral Fluence After Propagation at E=' + repr(round(ec1)) + ' eV'], units=['m', 'm', 'J/eV/mm^2'])
+uti_plot2d1d(arI1vsXY, plotMeshI1vsX, plotMeshI1vsY, labels=['Horizontal Position', 'Vertical Position', 'Spectral Fluence After Propagation at E=' + str(round(ec1)) + ' eV'], units=['m', 'm', 'J/eV/mm^2'])
 
 if(arF1vsXY != None):
     uti_plot2d1d(arF1vsXY, plotMeshI1vsX, plotMeshI1vsY, x=0, y=0, labels=['Horizontal Position', 'Vertical Position', 'Fluence After Propagation'], units=['m', 'm', 'J/mm^2'])
@@ -413,7 +413,7 @@ if(meshP1vsT != None):
 if(meshP1vsXY != None):
     plotMeshP1vsX = [meshP1vsXY.xStart, meshP1vsXY.xFin, meshP1vsXY.nx]
     plotMeshP1vsY = [meshP1vsXY.yStart, meshP1vsXY.yFin, meshP1vsXY.ny]
-    uti_plot2d1d(arP1vsXY, plotMeshP1vsX, plotMeshP1vsY, x=0, y=0, labels=['Horizontal Position', 'Vertical Position', 'Power Density After Propagation at t= ' + repr(round(tc1*1.e+15)) + ' fs'], units=['m', 'm', 'W/mm^2'])
+    uti_plot2d1d(arP1vsXY, plotMeshP1vsX, plotMeshP1vsY, x=0, y=0, labels=['Horizontal Position', 'Vertical Position', 'Power Density After Propagation at t= ' + str(round(tc1*1.e+15)) + ' fs'], units=['m', 'm', 'W/mm^2'])
 
 #TEST
 #plotMeshI2vsE = [meshI2vsE.eStart, meshI2vsE.eFin, meshI2vsE.ne]

--- a/env/python/srwpy/srwl_bl.py
+++ b/env/python/srwpy/srwl_bl.py
@@ -1463,7 +1463,7 @@ class SRWLBeamline(object):
     #                         nameCore = _fname[:indLastDot]
     #                         sExt = _fname[indLastDot:len_fname] #extension with '.'
     #                     for i in range(6):
-    #                         fnPol = nameCore + '_' + repr(i) + sExt
+    #                         fnPol = nameCore + '_' + str(i) + sExt
     #                         srwl_uti_save_intens_ascii(arI[i], stk.mesh, fnPol, 0, ['Photon Energy', 'Horizontal Position', 'Vertical Position', sValName], _arUnits=['eV', 'm', 'm', sValUnitName])
     #     return arI
 
@@ -2026,7 +2026,7 @@ class SRWLBeamline(object):
                 for i in range(nInd):
                     curRadData = radView[i]
                     if((len(curRadData) > 6) and (curRadData[6] is not None)):
-                        curIntFileName = intNameCore + '_intermed_' + repr(curRadData[0]) + '.' + sExt
+                        curIntFileName = intNameCore + '_intermed_' + str(curRadData[0]) + '.' + sExt
                         #DEBUG
                         #print(curIntFileName)
                         #END DEBUG
@@ -3922,7 +3922,7 @@ class SRWLBeamline(object):
                                 [curMesh.yStart, curMesh.yFin, curMesh.ny],
                                 0, #0.5*(curMesh.xStart + curMesh.xFin),
                                 0, #0.5*(curMesh.yStart + curMesh.yFin),
-                                ['Horizontal Position', 'Vertical Position', sValLabel + ' After Elem. #' + repr(curIntData[0])],
+                                ['Horizontal Position', 'Vertical Position', sValLabel + ' After Elem. #' + str(curIntData[0])],
                                 ['m', 'm', sValUnit],
                                 True)
                             

--- a/env/python/srwpy/srwlib.py
+++ b/env/python/srwpy/srwlib.py
@@ -259,15 +259,15 @@ class SRWLMagFld3D(SRWLMagFld):
     def save_ascii(self, _file_path, _xc=0, _yc=0, _zc=0):
         """Auxiliary function to write tabulated Arbitrary 3D Magnetic Field data to ASCII file"""
         sHead = '#Bx [T], By [T], Bz [T] on 3D mesh: inmost loop vs X (horizontal transverse position), outmost loop vs Z (longitudinal position)\n'
-        sHead += '#' + repr(-0.5*self.rx + _xc) + ' #initial X position [m]\n'
-        sHead += '#' + repr(0. if(self.nx <= 1) else self.rx/(self.nx - 1)) + ' #step of X [m]\n'
-        sHead += '#' + repr(self.nx) + ' #number of points vs X\n'
-        sHead += '#' + repr(-0.5*self.ry + _yc) + ' #initial Y position [m]\n'
-        sHead += '#' + repr(0. if(self.ny <= 1) else self.ry/(self.ny - 1)) + ' #step of Y [m]\n'
-        sHead += '#' + repr(self.ny) + ' #number of points vs Y\n'
-        sHead += '#' + repr(-0.5*self.rz + _zc) + ' #initial Z position [m]\n'
-        sHead += '#' + repr(0. if(self.nz <= 1) else self.rz/(self.nz - 1)) + ' #step of Z [m]\n'
-        sHead += '#' + repr(self.nz) + ' #number of points vs Z\n'
+        sHead += '#' + str(-0.5*self.rx + _xc) + ' #initial X position [m]\n'
+        sHead += '#' + str(0. if(self.nx <= 1) else self.rx/(self.nx - 1)) + ' #step of X [m]\n'
+        sHead += '#' + str(self.nx) + ' #number of points vs X\n'
+        sHead += '#' + str(-0.5*self.ry + _yc) + ' #initial Y position [m]\n'
+        sHead += '#' + str(0. if(self.ny <= 1) else self.ry/(self.ny - 1)) + ' #step of Y [m]\n'
+        sHead += '#' + str(self.ny) + ' #number of points vs Y\n'
+        sHead += '#' + str(-0.5*self.rz + _zc) + ' #initial Z position [m]\n'
+        sHead += '#' + str(0. if(self.nz <= 1) else self.rz/(self.nz - 1)) + ' #step of Z [m]\n'
+        sHead += '#' + str(self.nz) + ' #number of points vs Z\n'
         arColsWr = [self.arBx, self.arBy, self.arBz]
         #print(self.nx, self.rx, self.ny, self.ry, self.nz, self.rz)
         srwl_uti_write_data_cols(_file_path, arColsWr, '\t', sHead)
@@ -694,13 +694,13 @@ class SRWLPrtTrj(object):
             ctStep = (self.ctEnd - self.ctStart)/(self.np - 1)
         ct = self.ctStart
         for i in range(self.np):
-            resStr = str(ct) + '\t' + repr(self.arX[i]) + '\t' + repr(self.arXp[i]) + '\t' + repr(self.arY[i]) + '\t' + repr(self.arYp[i]) + '\t' + repr(self.arZ[i]) + '\t' + repr(self.arZp[i])
+            resStr = str(ct) + '\t' + str(self.arX[i]) + '\t' + str(self.arXp[i]) + '\t' + str(self.arY[i]) + '\t' + str(self.arYp[i]) + '\t' + str(self.arZ[i]) + '\t' + str(self.arZp[i])
             if(hasattr(self, 'arBx')):
-                resStr += '\t' + repr(self.arBx[i])
+                resStr += '\t' + str(self.arBx[i])
             if(hasattr(self, 'arBy')):
-                resStr += '\t' + repr(self.arBy[i])
+                resStr += '\t' + str(self.arBy[i])
             if(hasattr(self, 'arBz')):
-                resStr += '\t' + repr(self.arBz[i])
+                resStr += '\t' + str(self.arBz[i])
             f.write(resStr + '\n')        
             ct += ctStep
         f.close()
@@ -2191,7 +2191,7 @@ class SRWLStokes(object):
                             nameCore = _fname[:indLastDot]
                             sExt = _fname[indLastDot:len_fname] #extension with '.'
                         for i in range(6):
-                            fnPol = nameCore + '_' + repr(i) + sExt
+                            fnPol = nameCore + '_' + str(i) + sExt
                             srwl_uti_save_intens_ascii(arI[i], self.mesh, fnPol, 0, ['Photon Energy', 'Horizontal Position', 'Vertical Position', sValName], _arUnits=['eV', 'm', 'm', sValUnitName]) #OC27122023
                             #srwl_uti_save_intens_ascii(arI[i], stk.mesh, fnPol, 0, ['Photon Energy', 'Horizontal Position', 'Vertical Position', sValName], _arUnits=['eV', 'm', 'm', sValUnitName])
         return arI
@@ -6835,34 +6835,34 @@ def srwl_uti_save_intens_ascii(_ar_intens, _mesh, _file_path, _n_stokes=1, _arLa
     #print(sUnitEnt) #DEBUG
     
     f.write('#' + sUnitEnt + ' (C-aligned, inner loop is vs ' + _arLabels[0] + ', outer loop vs ' + _arLabels[2] + ')\n')
-    f.write('#' + repr(_mesh.eStart) + ' #Initial ' + arLabelUnit[0] + '\n')
-    f.write('#' + repr(_mesh.eFin) + ' #Final ' + arLabelUnit[0] + '\n')
-    f.write('#' + repr(_mesh.ne) + ' #Number of points vs ' + _arLabels[0] + '\n')
-    f.write('#' + repr(_mesh.xStart) + ' #Initial ' + arLabelUnit[1] + '\n')
-    f.write('#' + repr(_mesh.xFin) + ' #Final ' + arLabelUnit[1] + '\n')
-    f.write('#' + repr(_mesh.nx) + ' #Number of points vs ' + _arLabels[1] + '\n')
-    f.write('#' + repr(_mesh.yStart) + ' #Initial ' + arLabelUnit[2] + '\n')
-    f.write('#' + repr(_mesh.yFin) + ' #Final ' + arLabelUnit[2] + '\n')
-    f.write('#' + repr(_mesh.ny) + ' #Number of points vs ' + _arLabels[2] + '\n')
+    f.write('#' + str(_mesh.eStart) + ' #Initial ' + arLabelUnit[0] + '\n')
+    f.write('#' + str(_mesh.eFin) + ' #Final ' + arLabelUnit[0] + '\n')
+    f.write('#' + str(_mesh.ne) + ' #Number of points vs ' + _arLabels[0] + '\n')
+    f.write('#' + str(_mesh.xStart) + ' #Initial ' + arLabelUnit[1] + '\n')
+    f.write('#' + str(_mesh.xFin) + ' #Final ' + arLabelUnit[1] + '\n')
+    f.write('#' + str(_mesh.nx) + ' #Number of points vs ' + _arLabels[1] + '\n')
+    f.write('#' + str(_mesh.yStart) + ' #Initial ' + arLabelUnit[2] + '\n')
+    f.write('#' + str(_mesh.yFin) + ' #Final ' + arLabelUnit[2] + '\n')
+    f.write('#' + str(_mesh.ny) + ' #Number of points vs ' + _arLabels[2] + '\n')
 
     #strOut =  '#' + sUnitEnt + ' (C-aligned, inner loop is vs ' + _arLabels[0] + ', outer loop vs ' + _arLabels[2] + ')\n'
-    #strOut += '#' + repr(_mesh.eStart) + ' #Initial ' + arLabelUnit[0] + '\n'
-    #strOut += '#' + repr(_mesh.eFin) + ' #Final ' + arLabelUnit[0] + '\n'
-    #strOut += '#' + repr(_mesh.ne) + ' #Number of points vs ' + _arLabels[0] + '\n'
-    #strOut += '#' + repr(_mesh.xStart) + ' #Initial ' + arLabelUnit[1] + '\n'
-    #strOut += '#' + repr(_mesh.xFin) + ' #Final ' + arLabelUnit[1] + '\n'
-    #strOut += '#' + repr(_mesh.nx) + ' #Number of points vs ' + _arLabels[1] + '\n'
-    #strOut += '#' + repr(_mesh.yStart) + ' #Initial ' + arLabelUnit[2] + '\n'
-    #strOut += '#' + repr(_mesh.yFin) + ' #Final ' + arLabelUnit[2] + '\n'
-    #strOut += '#' + repr(_mesh.ny) + ' #Number of points vs ' + _arLabels[2] + '\n'
+    #strOut += '#' + str(_mesh.eStart) + ' #Initial ' + arLabelUnit[0] + '\n'
+    #strOut += '#' + str(_mesh.eFin) + ' #Final ' + arLabelUnit[0] + '\n'
+    #strOut += '#' + str(_mesh.ne) + ' #Number of points vs ' + _arLabels[0] + '\n'
+    #strOut += '#' + str(_mesh.xStart) + ' #Initial ' + arLabelUnit[1] + '\n'
+    #strOut += '#' + str(_mesh.xFin) + ' #Final ' + arLabelUnit[1] + '\n'
+    #strOut += '#' + str(_mesh.nx) + ' #Number of points vs ' + _arLabels[1] + '\n'
+    #strOut += '#' + str(_mesh.yStart) + ' #Initial ' + arLabelUnit[2] + '\n'
+    #strOut += '#' + str(_mesh.yFin) + ' #Final ' + arLabelUnit[2] + '\n'
+    #strOut += '#' + str(_mesh.ny) + ' #Number of points vs ' + _arLabels[2] + '\n'
             
     nComp = 1
     if _n_stokes > 0:
-        f.write('#' + repr(_n_stokes) + ' #Number of components\n')
+        f.write('#' + str(_n_stokes) + ' #Number of components\n')
         #DEBUG
-        #print('#' + repr(_n_stokes) + ' #Number of components\n')
+        #print('#' + str(_n_stokes) + ' #Number of components\n')
         
-        #strOut += '#' + repr(_n_stokes) + ' #Number of components\n'
+        #strOut += '#' + str(_n_stokes) + ' #Number of components\n'
         nComp = _n_stokes
     nRadPt = _mesh.ne*_mesh.nx*_mesh.ny
     if(_mutual > 0): nRadPt *= nRadPt
@@ -6878,8 +6878,8 @@ def srwl_uti_save_intens_ascii(_ar_intens, _mesh, _file_path, _n_stokes=1, _arLa
     #END DEBUG
 
     for i in range(nVal): #write all data into one column using "C-alignment" as a "flat" 1D array
-        f.write(' ' + repr(_ar_intens[i]) + '\n')
-        #strOut += ' ' + repr(_ar_intens[i]) + '\n'
+        f.write(' ' + str(_ar_intens[i]) + '\n')
+        #strOut += ' ' + str(_ar_intens[i]) + '\n'
         #DEBUG
         #if(_ar_intens[i] != 0.): print('i=', i, ' Non-zero Int. value:', _ar_intens[i])
         #if(i > 450000): break
@@ -7236,19 +7236,19 @@ def srwl_uti_save_intens_hdf5_exp(_ar_intens, _mesh, _file_path, _exp_type='XPCS
 #     f = open(_file_path + '-ascii.dat', 'w')
     
 #     f.write('#' + sUnitEnt + ' (C-aligned, inner loop is vs ' + arLabels[0] + ', outer loop vs ' + arLabels[2] + ')\n')
-#     f.write('#' + repr(eStart) + ' #Initial ' + arLabelUnit[0] + '\n')
-#     f.write('#' + repr(eFin) + ' #Final ' + arLabelUnit[0] + '\n')
-#     f.write('#' + repr(ne) + ' #Number of points vs ' + arLabels[0] + '\n')
-#     f.write('#' + repr(xStart) + ' #Initial ' + arLabelUnit[1] + '\n')
-#     f.write('#' + repr(xFin) + ' #Final ' + arLabelUnit[1] + '\n')
-#     f.write('#' + repr(nx) + ' #Number of points vs ' + arLabels[1] + '\n')
-#     f.write('#' + repr(yStart) + ' #Initial ' + arLabelUnit[2] + '\n')
-#     f.write('#' + repr(yFin) + ' #Final ' + arLabelUnit[2] + '\n')
-#     f.write('#' + repr(ny) + ' #Number of points vs ' + arLabels[2] + '\n')
+#     f.write('#' + str(eStart) + ' #Initial ' + arLabelUnit[0] + '\n')
+#     f.write('#' + str(eFin) + ' #Final ' + arLabelUnit[0] + '\n')
+#     f.write('#' + str(ne) + ' #Number of points vs ' + arLabels[0] + '\n')
+#     f.write('#' + str(xStart) + ' #Initial ' + arLabelUnit[1] + '\n')
+#     f.write('#' + str(xFin) + ' #Final ' + arLabelUnit[1] + '\n')
+#     f.write('#' + str(nx) + ' #Number of points vs ' + arLabels[1] + '\n')
+#     f.write('#' + str(yStart) + ' #Initial ' + arLabelUnit[2] + '\n')
+#     f.write('#' + str(yFin) + ' #Final ' + arLabelUnit[2] + '\n')
+#     f.write('#' + str(ny) + ' #Number of points vs ' + arLabels[2] + '\n')
             
 #     nComp = 1
 #     if n_stokes > 0:
-#         f.write('#' + repr(n_stokes) + ' #Number of components\n')
+#         f.write('#' + str(n_stokes) + ' #Number of components\n')
 #         nComp = n_stokes
 #     nRadPt = ne*nx*ny
 #     if(mutual > 0): nRadPt *= nRadPt
@@ -7257,7 +7257,7 @@ def srwl_uti_save_intens_hdf5_exp(_ar_intens, _mesh, _file_path, _exp_type='XPCS
 #     if(cmplx != 0): nVal *= 2 #OC06052018
 
 #     for ii in range(nVal): #write all data into one column using "C-alignment" as a "flat" 1D array
-#         f.write(' ' + repr(intensity_data[ii]) + '\n')
+#         f.write(' ' + str(intensity_data[ii]) + '\n')
 
 #     f.close()
 
@@ -7732,7 +7732,7 @@ def srwl_uti_write_data_cols(_file_path, _cols, _str_sep, _str_head=None, _i_col
         curLine = ''
         for j in range(_i_col_start, iColEndP1):
             curElem = ' '
-            if(i < len(_cols[j])): curElem = repr(_cols[j][i])
+            if(i < len(_cols[j])): curElem = str(_cols[j][i])
             curLine += curElem
             if(j < iColEnd): curLine += strSep
         if(i < nLinesM1): curLine += '\n'
@@ -7837,7 +7837,7 @@ def srwl_uti_save_stat_wfr_emit_prop_multi_e_init(num_of_proc, num_part_avg_proc
     timestamp = '{:%Y-%m-%d_%H-%M-%S}'.format(datetime.datetime.now()) 
     #log_file = 'srwl_stat_wfr_emit_prop_multi_e_{}'.format(timestamp)
     log_file = 'srwl_stat_wfr_emit_prop_multi_e_' #OC02032021
-    if(_i_gr is not None): log_file += repr(_i_gr) #OC02032021
+    if(_i_gr is not None): log_file += str(_i_gr) #OC02032021
     log_file += '{}' #OC02032021
     log_file = log_file.format(timestamp) #OC02032021
 
@@ -8048,7 +8048,7 @@ def srwl_wfr_prop_drifts(_wfr, _dz, _nz, _pp, _do3d=False, _nx=-1, _ny=-1, _rx=0
     for iz in range(0, nzp1):
 
         if(iz > 0):
-            print('Propagation (step # ' + repr(iz) + ') ... ', end='')
+            print('Propagation (step # ' + str(iz) + ') ... ', end='')
             t0 = time.time();
             srwl.PropagElecField(_wfr, cntDrift)
             print('completed (lasted', round(time.time() - t0, 6), 's)')
@@ -8312,8 +8312,8 @@ def srwl_wfr_csd_avg(_fp_core, _fp_ext, _fi_st, _fi_en, _csd0=None, _awfr=None, 
     awfr = _awfr #OC10102021
     for j in range(fi_st, _fi_en+1):
 
-        curFP = _fp_core + '_' + repr(j) + _fp_ext
-        #curFP = _fp_core + repr(j) + _fp_ext
+        curFP = _fp_core + '_' + str(j) + _fp_ext
+        #curFP = _fp_core + str(j) + _fp_ext
         curFP = srwl_wfr_fn(curFP, 3) #adds suffix "_mi" before extension
 
         #DEBUG
@@ -8832,7 +8832,7 @@ def srwl_wfr_emit_prop_multi_e(_e_beam, _mag, _mesh, _sr_meth, _sr_rel_prec, _n_
             #END DEBUG
 
             fp_cm = srwl_wfr_fn(_file_path, _type=7, _form='hdf5') #OC28062021
-            _file_path = fpCore + '_' + repr(iGr) + fpExt #OC28062021: to change this (the input file name should not be changed!)
+            _file_path = fpCore + '_' + str(iGr) + fpExt #OC28062021: to change this (the input file name should not be changed!)
 
     else: #if not ((_char == 6) or (_char == 61) or (_char == 7)): #OC28042022
         if(_n_mpi > 1): raise Exception("Calculation with more than one \"group\" of MPI processes is is not supported for this radiation characteristic.")
@@ -10547,7 +10547,7 @@ def srwl_wfr_emit_prop_multi_e(_e_beam, _mag, _mesh, _sr_meth, _sr_rel_prec, _n_
                         #END DEBUG
                         #DEBUG
                         #print('Saving intensity of propagated wavefront #', i)
-                        #srwl_uti_save_intens_ascii(workStokes.arS, workStokes.mesh, _file_path + '_' + repr(i) + '.dat', 1, _mutual = doMutual)
+                        #srwl_uti_save_intens_ascii(workStokes.arS, workStokes.mesh, _file_path + '_' + str(i) + '.dat', 1, _mutual = doMutual)
                         #sys.exit()
                         #END DEBUG
 
@@ -11560,7 +11560,7 @@ def srwl_wfr_emit_prop_multi_e(_e_beam, _mag, _mesh, _sr_meth, _sr_rel_prec, _n_
                 # #for j in range(_n_mpi):
 
                 #     #if(j > 0): #OC25042021 (commented-out)
-                #     curFP = fpCore + '_' + repr(j) + fpExt
+                #     curFP = fpCore + '_' + str(j) + fpExt
                 #     curFP = srwl_wfr_fn(curFP, 3) #adds suffix "_mi" before extension
 
                 #     resPartMI = srwl_uti_read_intens(_file_path=curFP, _form=_file_form)

--- a/env/python/srwpy/uti_io.py
+++ b/env/python/srwpy/uti_io.py
@@ -151,7 +151,7 @@ def write_ascii_data_cols(_file_path, _cols, _str_sep, _str_head=None, _i_col_st
         curLine = ''
         for j in range(_i_col_start, iColEndP1):
             curElem = ' '
-            if(i < len(_cols[j])): curElem = repr(_cols[j][i])
+            if(i < len(_cols[j])): curElem = str(_cols[j][i])
             curLine += curElem
             if(j < iColEnd): curLine += strSep
         if(i < nLinesM1): curLine += '\n'
@@ -209,7 +209,7 @@ def write_ascii_data_rows(_file_path, _rows, _str_sep, _str_head=None, _i_col_st
         curLine = ''
         curDataRow = _rows[i]
         for j in range(_i_col_start, iColEndP1):
-            curElem = repr(curDataRow[j])
+            curElem = str(curDataRow[j])
             curLine += curElem
             if(j < iColEnd): curLine += strSep
         if(i < iRowEnd): curLine += '\n'


### PR DESCRIPTION
With numpy 2.x, `repr(numpy.float64(1))` outputs `numpy.float(1.0)`, which is incorrect in most situations. 

In Python 2, `repr` was used over `str`, because `str` rounded the output. Since Python 3.1, this is no longer true. The correct way to convert to a string is `str` in Python 3.

This PR replaces all `repr` calls to `str` in the Python code including examples.
