### PR TITLE
Allow compilation on non-x86_64 architectures (e.g., Apple Silicon)

### DIFF
--- a/cpp/cmake/CMakeLists.txt
+++ b/cpp/cmake/CMakeLists.txt
@@ -39,7 +39,10 @@ endif()
 
 # Setup definitions for all targets
 add_definitions(${SRW_DEFINITIONS})
-add_compile_options(-O3 -mfma) #HG01082025
+add_compile_options(-O3)
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|i[3-6]86)$")
+    add_compile_options(-mfma) #HG01082025
+endif()
 
 #ext
 #auxgpu


### PR DESCRIPTION
To allow installation from source on other architectures, changed to only apply `-mfma` when `CMAKE_SYSTEM_PROCESSOR` is x86-like.